### PR TITLE
Actions updates

### DIFF
--- a/.github/workflows/check-prod-build.yaml
+++ b/.github/workflows/check-prod-build.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies 
-        run: npm install
+        run: npm ci
       - name: Build Next.js app
         env:
           NEXT_PUBLIC_MESHDB_URL: http://127.0.0.1:8000/

--- a/.github/workflows/publish-and-deploy.yaml
+++ b/.github/workflows/publish-and-deploy.yaml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install SSH key
-      uses: shimataro/ssh-key-action@v2
+      uses: shimataro/ssh-key-action@d4fffb50872869abe2d9a9098a6d9c5aa7d16be4 # v2
       with:
         key: ${{ secrets.GRANDSVC_KEY }}
         name: id_ed25519 # optional


### PR DESCRIPTION
1. Use [npm ci](https://docs.npmjs.com/cli/v10/commands/npm-ci/) instead of `npm install`
2. Pin the last unpinned third-party action. `shimataro/ssh-key-action` to commit [d4fffb50872869abe2d9a9098a6d9c5aa7d16be4](https://github.com/shimataro/ssh-key-action/commit/d4fffb50872869abe2d9a9098a6d9c5aa7d16be4) = `@v2` Reasoning: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions