### PR TITLE
Simplify phone input

### DIFF
--- a/components/JoinForm/JoinForm.tsx
+++ b/components/JoinForm/JoinForm.tsx
@@ -2,11 +2,12 @@
 
 import { JoinFormInput, submitJoinForm } from "@/app/api";
 import 'react-phone-number-input/style.css';
-import PhoneInput from 'react-phone-number-input';
+import PhoneInput from 'react-phone-number-input/input';
 import { E164Number } from 'libphonenumber-js/core';
 import { toastErrorMessage } from "@/app/utils/toastErrorMessage";
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import { formatPhoneNumberIntl, parsePhoneNumber } from 'react-phone-number-input'
 
 import styles from './JoinForm.module.scss'
 
@@ -31,6 +32,13 @@ const JoinForm = () => {
         data[key] = value === 'on' ? true : false;
       } else if (key === 'zip') {
         data[key] = Number(value);
+      } else if (key === 'phone') {
+        const parsedPhone = parsePhoneNumber(value as string, "US");
+        if(parsedPhone?.number) {
+          data[key] = formatPhoneNumberIntl(parsedPhone?.number)
+        } else {
+          data[key] = value;
+        }
       } else {
         data[key] = value;
       }
@@ -102,7 +110,6 @@ const JoinForm = () => {
             name="phone"
             placeholder="Phone Number"
             defaultCountry="US"
-            international={true}
             value={phoneNumber}
             onChange={setPhoneNumber}/>
         </div>


### PR DESCRIPTION
Resolves #27 

This PR changes phone input on the join form from "international" to "US". This includes removing the "flag selector".

Behind the scenes, phone numbers such as `2813308004` still come across to meshdb as: `+1 281 330 8004` if they can successfully be parsed as a US phone number. Otherwise, whatever the user enters will be passed to meshdb to allow international numbers like `+34 915 47 99 09` to still be entered.