### PR TITLE
Fetch MeshDB URL from server

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,4 @@
+MESHDB_URL=http://127.0.0.1:8000
 NEXT_PUBLIC_MESHDB_URL=http://127.0.0.1:8000
 
 # Docker compose environment variables

--- a/app/api.ts
+++ b/app/api.ts
@@ -1,19 +1,12 @@
 "use client"
 import { JoinFormInput, JoinFormResponse, NNAssignFormInput, NNAssignFormResponse, QueryFormResponse } from "@/app/io";
 import { z } from "zod";
-
-if (process.env.NEXT_PUBLIC_MESHDB_URL === undefined) {
-  throw new Error('Expected API url environment variable');
-}
-
-//if (process.env.MESHDB_TOKEN === undefined) {
-//  throw new Error('Expected API token environment variable');
-//}
-
-const API_BASE = new URL(process.env.NEXT_PUBLIC_MESHDB_URL as string + "/api/v1/");
+import { getMeshDBAPIEndpoint } from "./endpoint";
 
 const get = async <S extends z.Schema>(url: string, schema: S, auth?: string, nextOptions?: NextFetchRequestConfig): Promise<ReturnType<S['parse']>> => {
-  const res = await fetch(new URL(url, API_BASE), {
+  console.log("Will GET: " + input)
+  const api_base = new URL(`${getMeshDBAPIEndpoint()}/api/v1/`);
+  const res = await fetch(new URL(url, api_base), {
     headers: {
       ...auth && { Authorization: `Bearer ${auth}` },
     },
@@ -26,7 +19,8 @@ const get = async <S extends z.Schema>(url: string, schema: S, auth?: string, ne
 
 const post = async <S extends z.Schema>(url: string, schema: S, input: unknown, auth?: string, method = 'POST'): Promise<ReturnType<S['parse']>> => {
   console.log("Will POST: " + input)
-  const res = await fetch(new URL(url, API_BASE), {
+  const api_base = new URL(`${await getMeshDBAPIEndpoint()}/api/v1/`);
+  const res = await fetch(new URL(url, api_base), {
     method,
     headers: {
       'Content-Type': 'application/json',

--- a/app/endpoint.ts
+++ b/app/endpoint.ts
@@ -1,0 +1,9 @@
+"use server"
+
+// Literally just ask the server what endpoint to use.
+export async function getMeshDBAPIEndpoint() {
+  if (process.env.MESHDB_URL === undefined) {
+    throw new Error('Expected MESHDB_URL environment variable');
+  }
+  return process.env.MESHDB_URL
+}

--- a/components/JoinForm/JoinForm.tsx
+++ b/components/JoinForm/JoinForm.tsx
@@ -85,7 +85,7 @@ const JoinForm = () => {
         theme: "colored",
       });
     } catch (e) {
-      console.log("Could not submit Join Form:");
+      console.error(`Could not submit Join Form: ${e}`);
       toastErrorMessage(e);
       setIsLoading(false);
       return;

--- a/tests/mock/handlers.ts
+++ b/tests/mock/handlers.ts
@@ -9,6 +9,7 @@ export default [
     const joinRequest = await request.json();
 
     if (!isDeepStrictEqual(joinRequest, expectedAPIRequestData)) {
+      console.error("Mock Join API is returning 400.");
       return HttpResponse.json(
         {"detail": "Mock failure. Request does not match expected request."}, { status: 400 }
       );


### PR DESCRIPTION
Basically, this should let us specify at runtime what the URL of MeshDB is supposed to be. Whenever a request is made, the client fetches the URL of MeshDB from the NodeJS server, and then uses it to build a URL to make a request to. This works, and the current way doesn't, because in NextJS you're allowed to specify environment variables at runtime on the server. 

It feels pretty janky, but what about this app isn't?