### PR TITLE
Add APM tracing

### DIFF
--- a/infra/helm/meshforms/values.yaml
+++ b/infra/helm/meshforms/values.yaml
@@ -11,7 +11,8 @@ fullnameOverride: "meshforms"
 serviceAccount:
   create: false
 
-podAnnotations: {}
+podAnnotations:
+  admission.datadoghq.com/js-lib.version: v5.22.0
 podLabels:
   app: meshforms
 

--- a/infra/helm/meshforms/values.yaml
+++ b/infra/helm/meshforms/values.yaml
@@ -12,7 +12,7 @@ serviceAccount:
   create: false
 
 podAnnotations:
-  admission.datadoghq.com/js-lib.version: v5.22.0
+  admission.datadoghq.com/js-lib.version: v5.22
 podLabels:
   app: meshforms
 


### PR DESCRIPTION
Adds APM tracing to the meshforms Deployment specifically. [Single-step APM](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/?tab=kubernetes) is still in beta and acted kinda weird, so we're doing this instead.