### PR TITLE
Always pull image

### DIFF
--- a/infra/helm/meshforms/values.yaml
+++ b/infra/helm/meshforms/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 3
 
 image:
   repository: willnilges/meshforms
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 imagePullSecrets: []
 nameOverride: "meshforms"


### PR DESCRIPTION
Always pulling + [bouncing](https://github.com/nycmeshnet/meshforms/blob/main/.github/workflows/deploy-to-k8s.yaml#L54) the deployment mean the service will be updated when deployed from CI