### PR TITLE
Fix broken links to installs on query form

### DIFF
--- a/components/QueryForm/QueryForm.tsx
+++ b/components/QueryForm/QueryForm.tsx
@@ -133,7 +133,7 @@ export function QueryForm() {
         cellRenderer: (props: any) => {
           return (
             <a
-              href={`${process.env.NEXT_PUBLIC_MESHDB_URL}/admin/meshapi/install/${props.value}`}
+              href={`${process.env.NEXT_PUBLIC_MESHDB_URL}/admin/meshapi/install/?q=${props.value}`}
             >
               {props.value}
             </a>


### PR DESCRIPTION
Since the UUID switch, install numbers can't be directly used in admin URLs