### PR TITLE
Add security headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,35 @@ const withNextIntl = createNextIntlPlugin();
 const nextConfig = {
   output: "standalone",
   trailingSlash: true,
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'accelerometer=(), ambient-light-sensor=(), autoplay=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), usb=()',
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=30',
+          },
+        ],
+      },
+    ]
+  },
 };
 
 module.exports = withNextIntl(nextConfig);

--- a/next.config.js
+++ b/next.config.js
@@ -9,31 +9,32 @@ const nextConfig = {
   async headers() {
     return [
       {
-        source: '/(.*)',
+        source: "/(.*)",
         headers: [
           {
-            key: 'X-Frame-Options',
-            value: 'DENY',
+            key: "X-Frame-Options",
+            value: "DENY",
           },
           {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff',
+            key: "X-Content-Type-Options",
+            value: "nosniff",
           },
           {
-            key: 'Referrer-Policy',
-            value: 'strict-origin-when-cross-origin',
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
           },
           {
-            key: 'Permissions-Policy',
-            value: 'accelerometer=(), ambient-light-sensor=(), autoplay=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), usb=()',
+            key: "Permissions-Policy",
+            value:
+              "accelerometer=(), ambient-light-sensor=(), autoplay=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), usb=()",
           },
           {
-            key: 'Strict-Transport-Security',
-            value: 'max-age=30',
+            key: "Strict-Transport-Security",
+            value: "max-age=30",
           },
         ],
       },
-    ]
+    ];
   },
 };
 


### PR DESCRIPTION
- X-Frame-Options - Don't allow meshforms to be loaded in an iframe
- X-Content-Type-Options - Don't allow content sniffing in old browsers
- Referrer-Policy - Minimize info sent in the referrer header for requests outside of the origin where meshforms is hosted
- Permissions-Policy - Tell the browser meshforms doesn't use niche browser APIs
- Strict-Transport-Security - Tell the browser to only send HTTPS requests to meshforms (initially set to a low number, raise later)