### PR TITLE
Increase HSTS max-age value

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -30,7 +30,7 @@ const nextConfig = {
           },
           {
             key: "Strict-Transport-Security",
-            value: "max-age=30",
+            value: "max-age=31536000",
           },
         ],
       },


### PR DESCRIPTION
Resolves #112 

Tells the browser to only talk to meshforms via HTTPS for the next year.