### PR TITLE
Add test to evoke 409 edge case

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -55,5 +55,14 @@
       "confirm": "Please confirm some information",
       "captchaFail": "Please complete an additional verification step to confirm your submission"
     }
+  },
+  "InfoConfirmation": {
+    "goBack": "Go Back",
+    "useOriginal": "Use Original",
+    "acceptChanges": "Accept Changes",
+    "pleaseConfirmHeader": "Please confirm some information",
+    "pleaseConfirmBody": "We needed to re-format some of your information. Please ensure that the below fields are accurate.",
+    "originalInformationColumnHeader": "Original",
+    "newInformationColumnHeader": "New"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1677,6 +1677,126 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.18.tgz",
+      "integrity": "sha512-uJCEjutt5VeJ30jjrHV1VIHCsbMYnEqytQgvREx+DjURd/fmKy15NaVK4aR/u98S1LGTnjq35lRTnRyygglxoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.18.tgz",
+      "integrity": "sha512-IL6rU8vnBB+BAm6YSWZewc+qvdL1EaA+VhLQ6tlUc0xp+kkdxQrVqAnh8Zek1ccKHlTDFRyAft0e60gteYmQ4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.18.tgz",
+      "integrity": "sha512-RCaENbIZqKKqTlL8KNd+AZV/yAdCsovblOpYFp0OJ7ZxgLNbV5w23CUU1G5On+0fgafrsGcW+GdMKdFjaRwyYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.18.tgz",
+      "integrity": "sha512-3kmv8DlyhPRCEBM1Vavn8NjyXtMeQ49ID0Olr/Sut7pgzaQTo4h01S7Z8YNE0VtbowyuAL26ibcz0ka6xCTH5g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.18.tgz",
+      "integrity": "sha512-mliTfa8seVSpTbVEcKEXGjC18+TDII8ykW4a36au97spm9XMPqQTpdGPNBJ9RySSFw9/hLuaCMByluQIAnkzlw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.18.tgz",
+      "integrity": "sha512-J5g0UFPbAjKYmqS3Cy7l2fetFmWMY9Oao32eUsBPYohts26BdrMUyfCJnZFQkX9npYaHNDOWqZ6uV9hSDPw9NA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.18.tgz",
+      "integrity": "sha512-Ynxuk4ZgIpdcN7d16ivJdjsDG1+3hTvK24Pp8DiDmIa2+A4CfhJSEHHVndCHok6rnLUzAZD+/UOKESQgTsAZGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.18.tgz",
+      "integrity": "sha512-dtRGMhiU9TN5nyhwzce+7c/4CCeykYS+ipY/4mIrGzJ71+7zNo55ZxCB7cAVuNqdwtYniFNR2c9OFQ6UdFIMcg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@open-draft/deferred-promise": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",

--- a/src/components/InfoConfirmation/InfoConfirmation.module.scss
+++ b/src/components/InfoConfirmation/InfoConfirmation.module.scss
@@ -11,3 +11,8 @@
   text-align: left;
   padding: 8px;
 }
+
+.centered {
+  display: flex;
+  justify-content: center;
+}

--- a/tests/02_join_form.spec.ts
+++ b/tests/02_join_form.spec.ts
@@ -492,7 +492,9 @@ test.describe("user triggered captchaV2", () => {
     await expectSuccess(page, unitTestTimeout);
   });
 
-  test("user triggered captchaV2 and trust me bro and reject changes", async ({ page }) => {
+  test("user triggered captchaV2 and trust me bro and reject changes", async ({
+    page,
+  }) => {
     test.setTimeout(joinFormTimeout * 2); // This is a really long test
     await page.goto("/join");
 
@@ -535,7 +537,9 @@ test.describe("user triggered captchaV2", () => {
     await expectSuccess(page, unitTestTimeout);
   });
 
-  test("user triggered captchaV2 and trust me bro and cancel and try again", async ({ page }) => {
+  test("user triggered captchaV2 and trust me bro and cancel and try again", async ({
+    page,
+  }) => {
     test.setTimeout(joinFormTimeout * 2); // This is a really long test
     await page.goto("/join");
 
@@ -579,7 +583,7 @@ test.describe("user triggered captchaV2", () => {
       .locator("[id='recaptcha-anchor']")
       .click();
 
-    // Try submitting again 
+    // Try submitting again
     await submitConfirmationDialogExpected(page, 2000);
 
     // 2 counts of voter fraud

--- a/tests/02_join_form.spec.ts
+++ b/tests/02_join_form.spec.ts
@@ -483,5 +483,4 @@ test.describe("user triggered captchaV2", () => {
 
     await expectSuccess(page, unitTestTimeout);
   });
-  
 });

--- a/tests/02_join_form.spec.ts
+++ b/tests/02_join_form.spec.ts
@@ -14,6 +14,7 @@ import {
   expectSuccess,
   sampleJoinRecord,
   findJoinRecord,
+  chomSt,
 } from "./util";
 import { isDeepStrictEqual } from "util";
 
@@ -169,8 +170,8 @@ test("street address trust me bro", async ({ page }) => {
 
   // Is the page title correct?
   await expect(page).toHaveTitle(/Join Our Community Network!/);
-  let data = structuredClone(sampleData);
-  data.street_address = "333 chom st";
+  let data: JoinFormValues = Object.assign({}, sampleData);
+  data.street_address = chomSt;
 
   // Set up sample data.
   await fillOutJoinForm(page, data);
@@ -447,4 +448,40 @@ test.describe("user triggered captchaV2", () => {
 
     await submitSuccessExpected(page, unitTestTimeout);
   });
+
+  test("user triggered captchaV2 and trust me bro", async ({ page }) => {
+    test.setTimeout(joinFormTimeout * 2); // This is a really long test
+    await page.goto("/join");
+
+    // Is the page title correct?
+    await expect(page).toHaveTitle(/Join Our Community Network!/);
+
+    // Set up sample data.
+    let botTriggeringData: JoinFormValues = Object.assign({}, sampleData);
+    botTriggeringData.street_address = chomSt;
+
+    await fillOutJoinForm(page, botTriggeringData);
+
+    await submitAndCheckToast(
+      page,
+      "Please complete an additional verification step to confirm your submission",
+    );
+
+    await page.waitForTimeout(1000);
+
+    // Make the robot check the "I'm not a robot" button (commit voter fraud)
+    await page
+      .locator("[title='reCAPTCHA']")
+      .nth(1)
+      .contentFrame()
+      .locator("[id='recaptcha-anchor']")
+      .click();
+
+    await submitConfirmationDialogExpected(page, 2000);
+
+    await page.locator("[name='reject']").click();
+
+    await expectSuccess(page, unitTestTimeout);
+  });
+  
 });

--- a/tests/02_join_form.spec.ts
+++ b/tests/02_join_form.spec.ts
@@ -491,4 +491,107 @@ test.describe("user triggered captchaV2", () => {
 
     await expectSuccess(page, unitTestTimeout);
   });
+
+  test("user triggered captchaV2 and trust me bro and reject changes", async ({ page }) => {
+    test.setTimeout(joinFormTimeout * 2); // This is a really long test
+    await page.goto("/join");
+
+    // Is the page title correct?
+    await expect(page).toHaveTitle(/Join Our Community Network!/);
+
+    // Set up sample data.
+    let botTriggeringData: JoinFormValues = Object.assign({}, sampleData);
+    botTriggeringData.street_address = chomSt;
+
+    await fillOutJoinForm(page, botTriggeringData);
+
+    await submitAndCheckToast(
+      page,
+      "Please complete an additional verification step to confirm your submission",
+    );
+
+    await page.waitForTimeout(1000);
+
+    // Make the robot check the "I'm not a robot" button (commit voter fraud)
+    await page
+      .locator("[title='reCAPTCHA']")
+      .nth(1)
+      .contentFrame()
+      .locator("[id='recaptcha-anchor']")
+      .click();
+
+    await submitConfirmationDialogExpected(page, 2000);
+
+    // 2 counts of voter fraud
+    await page
+      .locator("[title='reCAPTCHA']")
+      .nth(2)
+      .contentFrame()
+      .locator("[id='recaptcha-anchor']")
+      .click();
+
+    await page.locator("[name='reject']").click();
+
+    await expectSuccess(page, unitTestTimeout);
+  });
+
+  test("user triggered captchaV2 and trust me bro and cancel and try again", async ({ page }) => {
+    test.setTimeout(joinFormTimeout * 2); // This is a really long test
+    await page.goto("/join");
+
+    // Is the page title correct?
+    await expect(page).toHaveTitle(/Join Our Community Network!/);
+
+    // Set up sample data.
+    let botTriggeringData: JoinFormValues = Object.assign({}, sampleData);
+    botTriggeringData.street_address = chomSt;
+
+    // Fill out the form with our data
+    await fillOutJoinForm(page, botTriggeringData);
+
+    // Expect a warning asking us to do a captcha
+    await submitAndCheckToast(
+      page,
+      "Please complete an additional verification step to confirm your submission",
+    );
+
+    // Make the robot check the "I'm not a robot" button (commit voter fraud)
+    await page.waitForTimeout(1000);
+    await page
+      .locator("[title='reCAPTCHA']")
+      .nth(1)
+      .contentFrame()
+      .locator("[id='recaptcha-anchor']")
+      .click();
+
+    // Expect the dialogue to show up
+    await submitConfirmationDialogExpected(page, 2000);
+
+    // dismiss it
+    await page.waitForTimeout(1000);
+    await page.locator("[name='cancel']").click();
+
+    // Do the captcha again
+    await page
+      .locator("[title='reCAPTCHA']")
+      .nth(1)
+      .contentFrame()
+      .locator("[id='recaptcha-anchor']")
+      .click();
+
+    // Try submitting again 
+    await submitConfirmationDialogExpected(page, 2000);
+
+    // 2 counts of voter fraud
+    await page
+      .locator("[title='reCAPTCHA']")
+      .nth(2)
+      .contentFrame()
+      .locator("[id='recaptcha-anchor']")
+      .click();
+
+    await page.locator("[name='confirm']").click();
+
+    await expectSuccess(page, unitTestTimeout);
+  });
 });

--- a/tests/02_join_form.spec.ts
+++ b/tests/02_join_form.spec.ts
@@ -586,7 +586,7 @@ test.describe("user triggered captchaV2", () => {
     // Try submitting again
     await submitConfirmationDialogExpected(page, 2000);
 
-    // 2 counts of voter fraud
+    // 3 counts of voter fraud
     await page
       .locator("[title='reCAPTCHA']")
       .nth(2)

--- a/tests/02_join_form.spec.ts
+++ b/tests/02_join_form.spec.ts
@@ -479,7 +479,15 @@ test.describe("user triggered captchaV2", () => {
 
     await submitConfirmationDialogExpected(page, 2000);
 
-    await page.locator("[name='reject']").click();
+    // 2 counts of voter fraud
+    await page
+      .locator("[title='reCAPTCHA']")
+      .nth(2)
+      .contentFrame()
+      .locator("[id='recaptcha-anchor']")
+      .click();
+
+    await page.locator("[name='confirm']").click();
 
     await expectSuccess(page, unitTestTimeout);
   });

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -3,6 +3,9 @@ import { JoinRecord } from "@/lib/types";
 import { JoinFormValues } from "@/components/JoinForm/JoinForm";
 import { expect, Page } from "@playwright/test";
 
+export const chomSt = "333 chom st";
+export const chomStreet = "333 Chom Street";
+
 export const sampleData: JoinFormValues = {
   first_name: "Jon",
   last_name: "Smith",


### PR DESCRIPTION
Addresses #122

So I understand, the flow is:
- User fills out form
- User submits
- Captcha checks out? (this is the only way I could think of this happening)
- Dialogue comes up
- Confirm
- No token this time, so it rejects the submission?

I ask because I am seeing the captcha get triggered before any info confirmation logic happens (because the captcha is performed in the backend before we do anything with the join form data)

So like, if we could somehow re-use the tokens...