### PR TITLE
Add pre- and post-submissions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,5 +15,5 @@ COMPOSE_EXTERNAL_NETWORK=false
 COMPOSE_NETWORK_NAME=
 
 # Not required for local dev, unless the backend is configured to require captchas
-RECAPTCHA_V2_KEY=
-RECAPTCHA_V3_KEY=
+#RECAPTCHA_V2_KEY=
+#RECAPTCHA_V3_KEY=

--- a/.env.sample
+++ b/.env.sample
@@ -15,5 +15,5 @@ COMPOSE_EXTERNAL_NETWORK=false
 COMPOSE_NETWORK_NAME=
 
 # Not required for local dev, unless the backend is configured to require captchas
-#RECAPTCHA_V2_KEY=
-#RECAPTCHA_V3_KEY=
+RECAPTCHA_V2_KEY=
+RECAPTCHA_V3_KEY=

--- a/src/components/JoinForm/JoinForm.tsx
+++ b/src/components/JoinForm/JoinForm.tsx
@@ -14,7 +14,10 @@ import {
 } from "@mui/material";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
-import { maybeLogJoinRecordFailure, saveJoinRecordToS3 } from "@/lib/join_record";
+import {
+  maybeLogJoinRecordFailure,
+  saveJoinRecordToS3,
+} from "@/lib/join_record";
 import { getMeshDBAPIEndpoint, getRecaptchaKeys } from "@/lib/endpoint";
 import InfoConfirmationDialog from "../InfoConfirmation/InfoConfirmation";
 import { JoinRecord } from "@/lib/types";
@@ -192,13 +195,11 @@ export default function JoinForm() {
 
     let preJoinRecordFailed = true;
     let postJoinRecordFailed = true;
-    
+
     // Before we try anything else, submit the record to the pre-submission
     // S3 bucket for safety.
     try {
-      setJoinRecordKey(
-        await saveJoinRecordToS3(record, true),
-      );
+      setJoinRecordKey(await saveJoinRecordToS3(record, true));
       preJoinRecordFailed = false; // We got at least one joinRecord.
     } catch (error: unknown) {
       console.error(
@@ -349,7 +350,11 @@ export default function JoinForm() {
       }
 
       // If either JoinRecord failed to save, then we should log that.
-      maybeLogJoinRecordFailure(record, preJoinRecordFailed, postJoinRecordFailed);
+      maybeLogJoinRecordFailure(
+        record,
+        preJoinRecordFailed,
+        postJoinRecordFailed,
+      );
 
       // If we didn't get a JoinFormResponse, we're in trouble. Make sure that
       // we successfully saved the join record. If we didn't... oof.

--- a/src/components/JoinForm/JoinForm.tsx
+++ b/src/components/JoinForm/JoinForm.tsx
@@ -255,8 +255,11 @@ export default function JoinForm() {
       // FYI: The pre and post keys should be identical, except one of them will
       // have the "pre/" prefix and one will have the "post/" prefix
       try {
-        await saveJoinRecordToS3(record, false);
+        const postJoinRecordKey = await saveJoinRecordToS3(record, false);
         postJoinRecordFailed = false;
+        if (postJoinRecordKey !== "") {
+          setJoinRecordKey(postJoinRecordKey); // Might as well have the good one
+        }
       } catch (error: unknown) {
         console.error(
           `Could not upload JoinRecord to S3. ${JSON.stringify(error)}`,

--- a/src/lib/join_record.ts
+++ b/src/lib/join_record.ts
@@ -109,10 +109,16 @@ export async function getJoinRecordFromS3(key: string): Promise<JoinRecord> {
   return joinRecordS3.get(key);
 }
 
-export async function maybeLogJoinRecordFailure(joinRecord: JoinRecord, preJoinRecordFailed: boolean, postJoinRecordFailed: boolean) {
+export async function maybeLogJoinRecordFailure(
+  joinRecord: JoinRecord,
+  preJoinRecordFailed: boolean,
+  postJoinRecordFailed: boolean,
+) {
   if (!preJoinRecordFailed && !postJoinRecordFailed) {
     return;
   }
 
-  console.error(`JoinRecord failed to be submitted in S3 (pre failed: ${preJoinRecordFailed}) (post failed: ${postJoinRecordFailed}): ${joinRecord}`);
+  console.error(
+    `JoinRecord failed to be submitted in S3 (pre failed: ${preJoinRecordFailed}) (post failed: ${postJoinRecordFailed}): ${joinRecord}`,
+  );
 }

--- a/src/lib/join_record.ts
+++ b/src/lib/join_record.ts
@@ -44,8 +44,11 @@ class JoinRecordS3 {
       .replace(/[-:T]/g, "/")
       .slice(0, 19);
 
-    // Create the path
-    const key = `${this.PREFIX}${preSubmission ? "/pre" : "/post"}/${submissionKey}.json`;
+    // Create the path and specify
+    // - dev vs prod join record
+    // - pre vs post-join form submission
+    // - 2nd quartet of join record UUID (random but not too long)
+    const key = `${this.PREFIX}${preSubmission ? "/pre" : "/post"}/${joinRecord.uuid.split("-")[1]}/${submissionKey}.json`;
 
     let body = JSON.stringify(joinRecord);
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,7 +1,7 @@
 import { JoinFormValues } from "@/components/JoinForm/JoinForm";
 
 type JoinRecord = JoinFormValues & {
-  version: number,
+  version: number;
   uuid: string;
   submission_time: string;
   code: number | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
 import { JoinFormValues } from "@/components/JoinForm/JoinForm";
 
 type JoinRecord = JoinFormValues & {
+  uuid: string;
   submission_time: string;
   code: number | null;
   replayed: number;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
 import { JoinFormValues } from "@/components/JoinForm/JoinForm";
 
 type JoinRecord = JoinFormValues & {
+  version: number,
   uuid: string;
   submission_time: string;
   code: number | null;

--- a/tests/00_join_form_meshdb_500.spec.ts
+++ b/tests/00_join_form_meshdb_500.spec.ts
@@ -47,7 +47,9 @@ test("meshdb is 500ing but succeed anyway", async ({ page }) => {
   // needs our dotenv.
   const joinRecord: JoinRecord = await getJoinRecordFromS3(joinRecordKey);
 
+  // Crappy hack
   joinRecord.submission_time = sampleJoinRecord.submission_time;
+  joinRecord.uuid = sampleJoinRecord.uuid;
 
   // In this case, we know that we won't have a code or install number, so drop
   // those from the comparison

--- a/tests/01_join_form_meshdb_down.spec.ts
+++ b/tests/01_join_form_meshdb_down.spec.ts
@@ -52,6 +52,7 @@ test("meshdb is hard down but succeed anyway", async ({ page }) => {
   const joinRecord: JoinRecord = await getJoinRecordFromS3(joinRecordKey);
 
   joinRecord.submission_time = sampleJoinRecord.submission_time;
+  joinRecord.uuid = sampleJoinRecord.uuid;
 
   // In this case, we know that we won't have a code or install number, so drop
   // those from the comparison

--- a/tests/02_join_form.spec.ts
+++ b/tests/02_join_form.spec.ts
@@ -93,6 +93,7 @@ test("happy join form", async ({ page }) => {
 
   // This is fucked, sorry.
   joinRecord.submission_time = sampleJoinRecord.submission_time;
+  joinRecord.uuid = sampleJoinRecord.uuid;
 
   if (!isDeepStrictEqual(joinRecord, sampleJoinRecord)) {
     console.error("Expected:");

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -36,6 +36,8 @@ export const sampleJoinRecord: JoinRecord = {
   referral: "Mock Sample Data",
   ncl: true,
   trust_me_bro: false,
+  version: 2,
+  uuid: "1a55b949-0490-4b78-a2e8-10aea41d6f1d",
   submission_time: "2024-11-01T08:24:24",
   code: 201,
   replayed: 0,


### PR DESCRIPTION
Does away with the updating of join records, instead opting to submit two records to the bucket: One before submitting to MeshDB and one after.