### PR TITLE
Move UUID to end of join record key

### DIFF
--- a/src/components/JoinForm/JoinForm.tsx
+++ b/src/components/JoinForm/JoinForm.tsx
@@ -192,7 +192,7 @@ export default function JoinForm() {
     let record: JoinRecord = Object.assign(
       structuredClone(joinFormSubmission),
       {
-        version: 2,
+        version: 3,
         uuid: self.crypto.randomUUID(),
         submission_time: new Date().toISOString(),
         code: null,

--- a/src/lib/join_record.ts
+++ b/src/lib/join_record.ts
@@ -48,7 +48,7 @@ class JoinRecordS3 {
     // - dev vs prod join record
     // - pre vs post-join form submission
     // - 2nd quartet of join record UUID (random but not too long)
-    const key = `${this.PREFIX}${preSubmission ? "/pre" : "/post"}/${submissionKey}/${joinRecord.uuid.split("-")[1]}.json`;
+    const key = `${this.PREFIX}/v3/${preSubmission ? "/pre" : "/post"}/${submissionKey}/${joinRecord.uuid.split("-")[1]}.json`;
 
     let body = JSON.stringify(joinRecord);
 

--- a/src/lib/join_record.ts
+++ b/src/lib/join_record.ts
@@ -48,7 +48,7 @@ class JoinRecordS3 {
     // - dev vs prod join record
     // - pre vs post-join form submission
     // - 2nd quartet of join record UUID (random but not too long)
-    const key = `${this.PREFIX}/v3/${preSubmission ? "/pre" : "/post"}/${submissionKey}/${joinRecord.uuid.split("-")[1]}.json`;
+    const key = `${this.PREFIX}/v3/${preSubmission ? "pre" : "post"}/${submissionKey}/${joinRecord.uuid.split("-")[1]}.json`;
 
     let body = JSON.stringify(joinRecord);
 

--- a/src/lib/join_record.ts
+++ b/src/lib/join_record.ts
@@ -48,7 +48,7 @@ class JoinRecordS3 {
     // - dev vs prod join record
     // - pre vs post-join form submission
     // - 2nd quartet of join record UUID (random but not too long)
-    const key = `${this.PREFIX}${preSubmission ? "/pre" : "/post"}/${joinRecord.uuid.split("-")[1]}/${submissionKey}.json`;
+    const key = `${this.PREFIX}${preSubmission ? "/pre" : "/post"}/${submissionKey}/${joinRecord.uuid.split("-")[1]}.json`;
 
     let body = JSON.stringify(joinRecord);
 

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -36,7 +36,7 @@ export const sampleJoinRecord: JoinRecord = {
   referral: "Mock Sample Data",
   ncl: true,
   trust_me_bro: false,
-  version: 2,
+  version: 3,
   uuid: "1a55b949-0490-4b78-a2e8-10aea41d6f1d",
   submission_time: "2024-11-01T08:24:24",
   code: 201,


### PR DESCRIPTION
Whoops, the way it is now, we have huge cardinality on our keys. This will fix that by moving the UUID to the end of the key.

I will have to go into the bucket and fix it separately.