### PR TITLE
Fix typo in legacy query form

### DIFF
--- a/src/components/QueryForm/QueryForm.tsx
+++ b/src/components/QueryForm/QueryForm.tsx
@@ -299,7 +299,7 @@ export function QueryForm() {
                   {r.stripe_email_address}
                 </a>
                 , <a href={"tel:" + r.phone_number}>{r.phone_number}</a>,{" "}
-                {r.network_number}, {r.network_number}, {r.status}
+                {r.network_number}, {r.network_number_status}, {r.status}
               </li>
             );
           })}


### PR DESCRIPTION
Must have fatfingered when I was setting up #141 on the legacy query form. Sorry Olivier!