### PR TITLE
Check if we should send a join record based on an env var

### DIFF
--- a/src/lib/endpoint.ts
+++ b/src/lib/endpoint.ts
@@ -34,3 +34,8 @@ export async function getRumApplicationID() {
 export async function getRumClientToken() {
   return process.env.RUM_CLIENT_TOKEN ?? "";
 }
+
+export async function shouldSendJoinRecord() {
+  // Should always default to sending join records.
+  return process.env.SEND_JOIN_RECORD ?? true;
+}


### PR DESCRIPTION
In order to save a little money and bandwith, we can stop sending Join Records for Dev. Since the synthetic fires so often, it creates a lot of join records.

One alternative to this I'll pose is perhaps reducing the retention of the bucket really short, and perhaps setting up another synthetic to check the bucket and ensure that it actually sent us a record.