### PR TITLE
Fix broken loggigng in theme provider

### DIFF
--- a/src/lib/EnvProvider.tsx
+++ b/src/lib/EnvProvider.tsx
@@ -15,6 +15,9 @@ interface EnvProviderProps {
   children: ReactNode;
 }
 
+// FIXME (wdn): I think there is a minor race condition here where the state is
+// briefly undefined the first time it's evaluated on a page. This is because
+// when you call set on a useState, it does not _immediately_ update.
 export const EnvProvider: React.FC<EnvProviderProps> = ({ children }) => {
   const [env, setEnv] = useState<string | undefined>(undefined);
   useEffect(() => {

--- a/src/lib/EnvThemeProvider.tsx
+++ b/src/lib/EnvThemeProvider.tsx
@@ -13,7 +13,11 @@ export const EnvThemeProvider: React.FC<EnvThemeProviderProps> = ({
 }) => {
   const env = useEnvContext();
 
-  console.log(env);
+  if (env === undefined) {
+    console.warn("Could not load env theme; env is undefined.");
+  }
+
+  console.log(`Loading environment: ${env}`);
 
   let theme = localTheme;
   if (env === undefined) {

--- a/src/lib/EnvThemeProvider.tsx
+++ b/src/lib/EnvThemeProvider.tsx
@@ -13,11 +13,13 @@ export const EnvThemeProvider: React.FC<EnvThemeProviderProps> = ({
 }) => {
   const env = useEnvContext();
 
+  // FIXME (wdn): The first time this is evaluated on a page, this will be undefined.
+  // see EnvProvider.tsx for more information
+  /*
   if (env === undefined) {
     console.warn("Could not load env theme; env is undefined.");
   }
-
-  console.log(`Loading environment: ${env}`);
+  */
 
   let theme = localTheme;
   if (env === undefined) {


### PR DESCRIPTION
This line was flooding our logs with `undefined`. It still is, but now it's clear where the warning is coming from.