### PR TITLE
Update Dockerfile for linter issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY . .
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN yarn build
 
@@ -34,9 +34,9 @@ FROM base AS runner
 RUN apk add curl
 WORKDIR /app
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 # Uncomment the following line in case you want to disable telemetry during runtime.
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
@@ -56,9 +56,9 @@ USER nextjs
 
 EXPOSE 80
 
-ENV PORT 80
+ENV PORT=80
 # set hostname to localhost
-ENV HOSTNAME "0.0.0.0"
+ENV HOSTNAME="0.0.0.0"
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output


### PR DESCRIPTION
>  Legacy key/value format with whitespace separator should not be used
> LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
> More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/

As seen at https://github.com/nycmeshnet/meshforms/pull/202/files
